### PR TITLE
PrChecker diagnosing query

### DIFF
--- a/src/behaviors/PrChecker.ts
+++ b/src/behaviors/PrChecker.ts
@@ -237,7 +237,11 @@ export default class PrChecker extends Behavior {
         completed_at: moment().toISOString(),
         output: {
           title: PrChecker.OUTPUT_TITLE,
-          summary: PrChecker.getSummaryMsg(conclusion, pull_requests[0].number, requiredApprovals),
+          summary: PrChecker.getSummaryMsg(
+            conclusion,
+            pull_requests[0] ? pull_requests[0].number : 0,
+            requiredApprovals,
+          ),
         },
       });
       checkResponseWith(await context.github.checks.update(inProgressFinish), {

--- a/src/utils/PrQueries.ts
+++ b/src/utils/PrQueries.ts
@@ -2,6 +2,7 @@ import { PullsGetParams } from '@octokit/rest';
 import { GitHubAPI } from 'probot/lib/github';
 import { Repo } from '../types/OctokitInterface';
 import { checkResponseStatus } from './OctokitUtils';
+import { getProbotApp } from '../globals';
 
 export async function getOrQueryPrsForCommit(
   api: GitHubAPI,
@@ -9,7 +10,10 @@ export async function getOrQueryPrsForCommit(
   sha: string,
   pull_requests?: PullsGetParams[],
 ): Promise<PullsGetParams[]> {
+  // TODO: Remove all logs in this function
+
   if (pull_requests && pull_requests.length > 0) {
+    getProbotApp().log.debug(`Commit ${sha} has PRs. Returning what was received in argument.`);
     return pull_requests;
   }
 
@@ -18,12 +22,15 @@ export async function getOrQueryPrsForCommit(
   });
 
   let retVal: PullsGetParams[] = [];
+  getProbotApp().log.debug(`Searching PRs for commit ${sha}.`);
   for await (const page of api.paginate.iterator(query)) {
     checkResponseStatus(page);
     for (const item of page.data) {
+      getProbotApp().log.debug(`Commit ${sha} has PR ${item.url}.`);
       // We return the PR that is placed in "our" repo.
       // Using the pull request repo URL to identify it.
       if (item.repository_url === `https://api.github.com/repos/${repo.owner}/${repo.repo}`) {
+        getProbotApp().log.debug(`Commit ${sha} has PR ${item.url} which is returned by getOrQueryPrsForCommit.`);
         retVal.push({ number: Number(item.number), ...repo });
       }
     }


### PR DESCRIPTION
Apparently, the list returned by getOrQueryPrsForCommit is sometimes empty.
Adding log messages to see if GitHub is returning an empty query or if conditionals are not OK.

Also, adding making the bot to not fail with a never ending "in progress" check. At least, the check should now finish with failure status, making it possible to request a re-check.